### PR TITLE
Custom spider argument support

### DIFF
--- a/arachnado/mixins.py
+++ b/arachnado/mixins.py
@@ -1,0 +1,28 @@
+import logging
+import datetime
+
+
+class ArachnadoSpiderMixin(object):
+    """
+    An arachnado spider mixin that contains common attributes and utilities for
+    all Arachnado spiders
+    """
+    crawl_id = None
+    domain = None
+    motor_job_id = None
+
+    def __init__(self, *args, **kwargs):
+        super(ArachnadoSpiderMixin, self).__init__(*args, **kwargs)
+        # don't log scraped items
+        logging.getLogger("scrapy.core.scraper").setLevel(logging.INFO)
+
+    def get_page_item(self, response, type_='page'):
+        return {
+            'crawled_at': datetime.datetime.utcnow(),
+            'url': response.url,
+            'status': response.status,
+            'headers': response.headers,
+            'body': response.body_as_unicode(),
+            'meta': response.meta,
+            '_type': type_,
+        }

--- a/arachnado/spider.py
+++ b/arachnado/spider.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import datetime
-import logging
 
 import scrapy
 from scrapy.linkextractors import LinkExtractor
 from scrapy.http.response.html import HtmlResponse
+from scrapy.spiders.crawl import CrawlSpider
 
 from .utils import MB, add_scheme_if_missing, get_netloc
 from .crawler_process import ArachnadoCrawler
+from .mixins import ArachnadoSpiderMixin
 
 
 DEFAULT_SETTINGS = {
@@ -68,30 +68,12 @@ def create_crawler(settings=None, spider_cls=None):
     return ArachnadoCrawler(spider_cls, _settings)
 
 
-class ArachnadoSpider(scrapy.Spider):
-    """
-    A base spider that contains common attributes and utilities for all
-    Arachnado spiders
-    """
-    crawl_id = None
-    domain = None
-    motor_job_id = None
+class ArachnadoSpider(scrapy.Spider, ArachnadoSpiderMixin):
+    pass
 
-    def __init__(self, *args, **kwargs):
-        super(ArachnadoSpider, self).__init__(*args, **kwargs)
-        # don't log scraped items
-        logging.getLogger("scrapy.core.scraper").setLevel(logging.INFO)
 
-    def get_page_item(self, response, type_='page'):
-        return {
-            'crawled_at': datetime.datetime.utcnow(),
-            'url': response.url,
-            'status': response.status,
-            'headers': response.headers,
-            'body': response.body_as_unicode(),
-            'meta': response.meta,
-            '_type': type_,
-        }
+class ArachnadoCrawlSpider(CrawlSpider, ArachnadoSpiderMixin):
+    pass
 
 
 class CrawlWebsiteSpider(ArachnadoSpider):


### PR DESCRIPTION
This PR introduces similar behavior about custom [spider arguments](http://doc.scrapy.org/en/latest/topics/spiders.html#spider-arguments) where arguments are embedded into the `request` under process.

The trick had to be done in `set_spider_class_args` is, creating a new class type based on original spider class to prevent arguments set in previous requests be persistent. 
The arguments could also be set after object instantiation but that would break the behavior compatibility with `scrapy.Spider` where arguments are already available in `__init__` method.