### PR TITLE
Py3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update; apt-get install -y --no-install-recommends \
     git \
     curl \
-    python \
-    python-pip \
-    python-dev \
+    python3 \
+    python3-pip \
+    python3-dev \
     build-essential \
     pkg-config \
     libsqlite3-dev \
@@ -15,8 +15,8 @@ RUN apt-get update; apt-get install -y --no-install-recommends \
     libxslt1-dev \
     zlib1g-dev \
     libssl-dev \
-    python-lxml
-RUN pip install -U pip setuptools
+    python3-lxml
+RUN pip3 install -U pip setuptools
 
 # install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
@@ -27,7 +27,7 @@ WORKDIR /app
 # Install Python packages. Requirements change less often than source code,
 # so this is above COPY . /app
 COPY ./requirements.txt /app/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Install npm packages required to build static files.
 COPY package.json /app/package.json
@@ -40,7 +40,7 @@ COPY . /app
 # if .dockerignore is not active (may happen with docker-compose or DockerHub)
 RUN npm install
 RUN npm run build
-RUN pip install .
+RUN pip3 install .
 
 # use e.g. -v /path/to/my/arachnado/config.conf:/etc/arachnado.conf
 # docker run option to override arachnado parameters

--- a/arachnado/handler_utils.py
+++ b/arachnado/handler_utils.py
@@ -9,7 +9,7 @@ class ApiHandler(web.RequestHandler):
 
     def prepare(self):
         if self.request.headers.get("Content-Type", "").startswith("application/json"):
-            self.json_args = json.loads(self.request.body)
+            self.json_args = json.loads(self.request.body.decode("utf-8"))
             self.is_json = True
         else:
             self.json_args = None

--- a/arachnado/handlers.py
+++ b/arachnado/handlers.py
@@ -8,7 +8,8 @@ from tornado.web import Application, RequestHandler, url, HTTPError
 from arachnado.utils.misc import json_encode
 from arachnado.monitor import Monitor
 from arachnado.handler_utils import ApiHandler, NoEtagsMixin
-from arachnado.rpc import MainRpcHttpHandler, MainRpcWebsocketHandler
+from arachnado.rpc import RpcHttpHandler
+from arachnado.rpc.ws import RpcWebsocketHandler
 
 
 at_root = lambda *args: os.path.join(os.path.dirname(__file__), *args)
@@ -35,8 +36,8 @@ def get_application(crawler_process, domain_crawlers,
         url(r"/crawler/resume", ResumeCrawler, context, name="resume"),
         url(r"/crawler/status", CrawlerStatus, context, name="status"),
         url(r"/ws-updates", Monitor, context, name="ws-updates"),
-        url(r"/ws-rpc", MainRpcWebsocketHandler, context, name="ws-rpc"),
-        url(r"/rpc", MainRpcHttpHandler, context, name="rpc"),
+        url(r"/ws-rpc", RpcWebsocketHandler, context, name="ws-rpc"),
+        url(r"/rpc", RpcHttpHandler, context, name="rpc"),
     ]
     return Application(
         handlers=handlers,

--- a/arachnado/pipelines/mongoexport.py
+++ b/arachnado/pipelines/mongoexport.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 def scrapy_item_to_dict(son):
     """Recursively convert scrapy.Item to dict"""
-    for key, value in son.items():
+    for key, value in list(son.items()):
         if isinstance(value, (scrapy.Item, dict)):
             son[key] = scrapy_item_to_dict(
                 son.pop(key)

--- a/arachnado/rpc/__init__.py
+++ b/arachnado/rpc/__init__.py
@@ -1,43 +1,43 @@
-import logging
+from functools import partial
 
-from arachnado.utils.misc import json_encode
-# A little monkey patching to have custom types encoded right
-from jsonrpclib import jsonrpc
-jsonrpc.jdumps = json_encode
-import tornadorpc
-from tornadorpc.json import JSONRPCHandler
+from jsonrpc import JSONRPCResponseManager
+from jsonrpc.dispatcher import Dispatcher
+from tornado.web import RequestHandler, asynchronous
 from tornado.concurrent import Future
 
-from arachnado.rpc.jobs import JobsRpc
-from arachnado.rpc.sites import SitesRpc
-from arachnado.rpc.pages import PagesRpc
+from arachnado.utils.misc import json_encode
+from arachnado.rpc.jobs import Jobs
+from arachnado.rpc.sites import Sites
+from arachnado.rpc.pages import Pages
 from arachnado.rpc.ws import JsonRpcWebsocketHandler
 
 
-logger = logging.getLogger(__name__)
-tornadorpc.config.verbose = True
-tornadorpc.config.short_errors = True
-
-
-class MainRpcHttpHandler(JSONRPCHandler):
+class MainRpcHttpHandler(RequestHandler):
     """ Main JsonRpc router for REST requests"""
 
     def initialize(self, *args, **kwargs):
-        self.jobs = JobsRpc(self, *args, **kwargs)
-        self.sites = SitesRpc(self, *args, **kwargs)
-        self.pages = PagesRpc(self, *args, **kwargs)
+        self.dispatcher = Dispatcher()
+        self.dispatcher.add_object(Jobs(self, *args, **kwargs))
+        self.dispatcher.add_object(Sites(self, *args, **kwargs))
+        self.dispatcher.add_object(Pages(self, *args, **kwargs))
 
-    def result(self, result):
-        if isinstance(result, Future):
-            result.add_done_callback(self._result)
+    @asynchronous
+    def post(self):
+        response = JSONRPCResponseManager.handle(
+            self.request.body, self.dispatcher)
+        if isinstance(response.result, Future):
+            response.result.add_done_callback(
+                partial(self.on_done, data=response.data))
         else:
-            self._result(result)
+            self.send_data(response.data)
 
-    def _result(self, result):
-        if isinstance(result, Future):
-            result = result.result()
-        self._results.append(result)
-        self._RPC_.response(self)
+    def on_done(self, future, *, data):
+        data['result'] = future.result()
+        self.send_data(data)
+
+    def send_data(self, data):
+        self.write(json_encode(data))
+        self.finish()
 
 
 class MainRpcWebsocketHandler(JsonRpcWebsocketHandler, MainRpcHttpHandler):

--- a/arachnado/rpc/__init__.py
+++ b/arachnado/rpc/__init__.py
@@ -9,22 +9,19 @@ from arachnado.utils.misc import json_encode
 from arachnado.rpc.jobs import Jobs
 from arachnado.rpc.sites import Sites
 from arachnado.rpc.pages import Pages
-from arachnado.rpc.ws import JsonRpcWebsocketHandler
 
 
-class MainRpcHttpHandler(RequestHandler):
-    """ Main JsonRpc router for REST requests"""
-
+class ArachnadoRPC(object):
+    """ Base class for all Arachnado RPC resources.
+    """
     def initialize(self, *args, **kwargs):
         self.dispatcher = Dispatcher()
         self.dispatcher.add_object(Jobs(self, *args, **kwargs))
         self.dispatcher.add_object(Sites(self, *args, **kwargs))
         self.dispatcher.add_object(Pages(self, *args, **kwargs))
 
-    @asynchronous
-    def post(self):
-        response = JSONRPCResponseManager.handle(
-            self.request.body, self.dispatcher)
+    def handle_request(self, body):
+        response = JSONRPCResponseManager.handle(body, self.dispatcher)
         if isinstance(response.result, Future):
             response.result.add_done_callback(
                 partial(self.on_done, data=response.data))
@@ -36,9 +33,16 @@ class MainRpcHttpHandler(RequestHandler):
         self.send_data(data)
 
     def send_data(self, data):
+        raise NotImplementedError
+
+
+class RpcHttpHandler(ArachnadoRPC, RequestHandler):
+    """ JsonRpc router for REST requests.
+    """
+    @asynchronous
+    def post(self):
+        self.handle_request(self.request.body)
+
+    def send_data(self, data):
         self.write(json_encode(data))
         self.finish()
-
-
-class MainRpcWebsocketHandler(JsonRpcWebsocketHandler, MainRpcHttpHandler):
-    """ Main JsonRpc router for WS stream"""

--- a/arachnado/rpc/__init__.py
+++ b/arachnado/rpc/__init__.py
@@ -28,7 +28,7 @@ class ArachnadoRPC(object):
         else:
             self.send_data(response.data)
 
-    def on_done(self, future, *, data):
+    def on_done(self, future, data):
         data['result'] = future.result()
         self.send_data(data)
 

--- a/arachnado/rpc/jobs.py
+++ b/arachnado/rpc/jobs.py
@@ -1,7 +1,7 @@
 import logging
 
 
-class JobsRpc(object):
+class Jobs(object):
 
     logger = logging.getLogger(__name__)
 

--- a/arachnado/rpc/pages.py
+++ b/arachnado/rpc/pages.py
@@ -1,7 +1,7 @@
 from arachnado.storages.mongotail import MongoTailStorage
 
 
-class PagesRpc(object):
+class Pages(object):
 
     def __init__(self, handler, item_storage, **kwargs):
         self.handler = handler

--- a/arachnado/rpc/sites.py
+++ b/arachnado/rpc/sites.py
@@ -1,9 +1,7 @@
 import logging
 
-from tornadorpc import async
 
-
-class SitesRpc(object):
+class Sites(object):
 
     logger = logging.getLogger(__name__)
 
@@ -11,11 +9,8 @@ class SitesRpc(object):
         self.handler = handler
         self.storage = site_storage
 
-    @async
     def list(self):
-        def _list(future):
-            self.handler.result(future.result())
-        self.storage.fetch().add_done_callback(_list)
+        return self.storage.fetch()
 
     def post(self, site):
         self.storage.create(site)
@@ -34,6 +29,7 @@ class SitesRpc(object):
                 self._publish(data, subscription)
             )
 
+    # TODO - call it!
     def _on_close(self):
         self.storage.unsubscribe(self.storage.available_subscriptions)
 

--- a/arachnado/rpc/sites.py
+++ b/arachnado/rpc/sites.py
@@ -29,7 +29,6 @@ class Sites(object):
                 self._publish(data, subscription)
             )
 
-    # TODO - call it!
     def _on_close(self):
         self.storage.unsubscribe(self.storage.available_subscriptions)
 

--- a/arachnado/rpc/stats.py
+++ b/arachnado/rpc/stats.py
@@ -1,7 +1,7 @@
 import logging
 
 
-class StatsRpc(object):
+class Stats(object):
 
     logger = logging.getLogger(__name__)
 

--- a/arachnado/rpc/ws.py
+++ b/arachnado/rpc/ws.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-import jsonrpclib
+# FIXME import jsonrpclib
 from tornado import websocket, gen
 import tornado.ioloop
 from tornado.web import RequestHandler
@@ -11,7 +11,7 @@ from arachnado.utils.misc import json_encode
 
 
 logger = logging.getLogger(__name__)
-jsonrpclib.config.use_jsonclass = False
+# FIXME jsonrpclib.config.use_jsonclass = False
 
 
 class JsonRpcWebsocketHandler(websocket.WebSocketHandler):

--- a/arachnado/rpc/ws.py
+++ b/arachnado/rpc/ws.py
@@ -1,78 +1,67 @@
 import json
 import logging
+import six
 
-# FIXME import jsonrpclib
-from tornado import websocket, gen
-import tornado.ioloop
+from tornado.ioloop import PeriodicCallback
+from tornado.concurrent import Future
 from tornado.web import RequestHandler
-from tornado.websocket import WebSocketClosedError
+from tornado import websocket, gen
 
 from arachnado.utils.misc import json_encode
+from arachnado.rpc import ArachnadoRPC
 
 
 logger = logging.getLogger(__name__)
-# FIXME jsonrpclib.config.use_jsonclass = False
 
 
-class JsonRpcWebsocketHandler(websocket.WebSocketHandler):
+class RpcWebsocketHandler(ArachnadoRPC, websocket.WebSocketHandler):
+    """ JsonRpc router for WS stream.
+    """
 
     def on_message(self, message):
-        self._results = []
         try:
-            msg = json.loads(message.encode('utf-8'))
+            msg = json.loads(message)
             event, data = msg['event'], msg['data']
         except (TypeError, ValueError):
-            logger.warn("Invalid message skipped" + message[:500])
+            logger.warn('Invalid message skipped: {!r}'.format(message[:500]))
             return
         if event == 'rpc:request':
-            self.on_event(data)
+            self.handle_request(json.dumps(data))
         else:
-            logger.warn("Unsupported event type: " + event)
+            logger.warn('Unsupported event type: {!r}'.format(event))
 
-    def on_event(self, data):
-        self._RPC_.run(self, json_encode(data))
-
-    def _result(self, result):
-        """A little hacky way to not close WS stream"""
-        self._RPC_finished = False
-        super(JsonRpcWebsocketHandler, self)._result(result)
-
-    def on_result(self, data):
-        return self.write_event('rpc:response', data)
-
-    def open(self):
-        """Forward open event to resource objects"""
-        for resource_name, resource in self.__dict__.iteritems():
-            if hasattr(RequestHandler, resource_name):
-                continue
-            if hasattr(resource, '_on_open'):
-                resource._on_open()
-
-        self.__pinger = tornado.ioloop.PeriodicCallback(
-            lambda: self.ping('PING'),
-            1000 * 15
-        )
-        self.__pinger.start()
-
-    def on_close(self):
-        """Forward on_close event to resource objects"""
-        self._RPC_finished = True
-        for resource_name, resource in self.__dict__.iteritems():
-            if hasattr(RequestHandler, resource_name):
-                continue
-            if hasattr(resource, '_on_close'):
-                resource._on_close()
-
-        self.__pinger.stop()
+    def send_data(self, data):
+        self.write_event('rpc:response', data)
 
     @gen.coroutine
     def write_event(self, event, data):
-        if isinstance(data, basestring):
+        if isinstance(data, six.string_types):
             data = json.loads(data)
         message = json_encode({'event': event, 'data': data})
         try:
-            msg_d = self.write_message(message)
-            if msg_d is not None:
-                yield msg_d
-        except WebSocketClosedError:
+            self.write_message(message)
+        except websocket.WebSocketClosedError:
             pass
+
+    def open(self):
+        """ Forward open event to resource objects.
+        """
+        for resource in self._resources():
+            if hasattr(resource, '_on_open'):
+                resource._on_open()
+        self._pinger = PeriodicCallback(lambda: self.ping(b'PING'), 1000 * 15)
+        self._pinger.start()
+
+    def on_close(self):
+        """ Forward on_close event to resource objects.
+        """
+        for resource in self._resources():
+            if hasattr(resource, '_on_close'):
+                resource._on_close()
+        self._pinger.stop()
+
+    def _resources(self):
+        for resource_name, resource in self.__dict__.items():
+            if hasattr(RequestHandler, resource_name):
+                continue
+            yield resource

--- a/arachnado/spidermiddlewares/pageitems.py
+++ b/arachnado/spidermiddlewares/pageitems.py
@@ -29,7 +29,7 @@ class PageItemsMiddleware(object):
             'crawled_at': datetime.datetime.utcnow(),
             'url': response.url,
             'status': response.status,
-            'headers': response.headers,
+            'headers': response.headers.to_unicode_dict(),
             'body': response.body_as_unicode(),
             'meta': response.meta,
             'items': items,

--- a/arachnado/storages/mongotail.py
+++ b/arachnado/storages/mongotail.py
@@ -1,4 +1,4 @@
-import pymongo
+import six
 from bson.objectid import ObjectId
 from tornado.gen import sleep, coroutine
 
@@ -28,7 +28,7 @@ class MongoTailStorage(MongoStorage):
         if self.tailing:
             raise RuntimeError('This storage is already tailing')
         self.tailing = True
-        if isinstance(last_object_id, basestring):
+        if isinstance(last_object_id, six.string_types):
             last_object_id = ObjectId(last_object_id)
 
         if query is not None:
@@ -76,7 +76,8 @@ class MongoTailStorage(MongoStorage):
                     stack.append(v)
                 elif isinstance(v, list):
                     stack.extend(v)
-                elif isinstance(v, unicode) and v.startswith(u'ObjectId('):
+                elif isinstance(v, six.string_types) \
+                        and v.startswith(u'ObjectId('):
                     d[k] = ObjectId(v[9:-1])
 
         return query

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ motor == 0.6.2
 pymongo==2.8        # required for motor 0.6.2
 docopt == 0.6.2
 service_identity
-tornadorpc == 0.1.1
+json-rpc==1.10.3
 croniter == 0.3.8
 autopager == 0.2
 autologin-middleware == 0.1.1

--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,11 @@ setup(
         'docopt >= 0.6',
         'service_identity',
         'motor >= 0.6.2',
+        'json-rpc >= 1.10',
         'autologin-middleware >= 0.1.1',
         'six',
     ],
-    extras_requires={
+    extras_require={
         'mongo': [],   # backwards compatibility
         'extras': ['autopager >= 0.2'],
     }

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'json-rpc >= 1.10',
         'autologin-middleware >= 0.1.1',
         'six',
+        'croniter >= 0.3.12',
     ],
     extras_require={
         'mongo': [],   # backwards compatibility


### PR DESCRIPTION
Adding py3 support, using json-rpc instead of tornadorpc, as it is better supported and works on py3.

I did test that UI words, at least the basic starting of the spider, pausing, stopping. but I don't know what else to test :) I also run doctests, the only issue is in the manhole module, which is not supported on py3.

Perhaps there is some error-handling code missing in the updated RPC support, I'll check that.

There is one thing that I did not quite understand about the old code - I left a comment at that place: https://github.com/TeamHG-Memex/arachnado/pull/17/files#r65716663