### PR TITLE
Fix spider_packages in the example docker arachnado.conf

### DIFF
--- a/arachnado/config/docker-example.conf
+++ b/arachnado/config/docker-example.conf
@@ -4,7 +4,7 @@
 ;
 [arachnado.scrapy]
 ; Packages to load spiders from (separated by whitespace)
-spider_packages = /python-packages
+spider_packages = example_project.spiders
 
 [arachnado.storage]
 ; it assumes there is a linked 'aracnhado-mongo' container


### PR DESCRIPTION
``spider_packages`` is a list of python packages, not paths