### PR TITLE
Request info: support splash requests

### DIFF
--- a/arachnado/crawler_process.py
+++ b/arachnado/crawler_process.py
@@ -300,7 +300,14 @@ class ArachnadoCrawlerProcess(CrawlerProcess):
 
     @classmethod
     def _request_info(cls, request):
-        return {'url': request.url, 'method': request.method}
+        info = {'url': request.url, 'method': request.method}
+        if 'splash' in request.meta:
+            splash_args = request.meta['splash'].get('args', {})
+            if 'url' in splash_args:
+                info['url'] = splash_args['url']
+            if 'http_method' in splash_args:
+                info['method'] = splash_args['http_method']
+        return info
 
     @classmethod
     def _slot_info(cls, key, slot):

--- a/arachnado/crawler_process.py
+++ b/arachnado/crawler_process.py
@@ -305,8 +305,7 @@ class ArachnadoCrawlerProcess(CrawlerProcess):
             splash_args = request.meta['splash'].get('args', {})
             if 'url' in splash_args:
                 info['url'] = splash_args['url']
-            if 'http_method' in splash_args:
-                info['method'] = splash_args['http_method']
+            info['method'] = splash_args.get('http_method', 'GET')
         return info
 
     @classmethod


### PR DESCRIPTION
So that when we are crawling via splash, original URLs are shown in the "Request queue" on the jobs page in the UI, instead of the splash URL.