### PR TITLE
Fix ProxyFromSettingsMiddleware with auth

### DIFF
--- a/arachnado/downloadermiddlewares/proxyfromsettings.py
+++ b/arachnado/downloadermiddlewares/proxyfromsettings.py
@@ -11,6 +11,7 @@ class ProxyFromSettingsMiddleware(HttpProxyMiddleware):
 
     def __init__(self, settings):
         self.proxies = {}
+        self.auth_encoding = settings.get('HTTPPROXY_AUTH_ENCODING')
         proxies = [
             ('http', settings.get('HTTP_PROXY')),
             ('https', settings.get('HTTPS_PROXY')),


### PR DESCRIPTION
Initializing of `auth_encoding` is done in `HttpProxyMiddleware.__init__`, and is required for proxies with authentication - without it they will fail to initialize the proxy (noticed it while working on autologin, which has the same middleware):

```
Traceback (most recent call last):
  File "/Users/kostia/shub/memex/autologin/autologin/middleware.py", line 53, in __init__
    self.proxies[type_] = self._get_proxy(url, type_)
  File "/Users/kostia/shub/memex/autologin/venv/lib/python3.4/site-packages/scrapy/downloadermiddlewares/httpproxy.py", line 38, in _get_proxy
    encoding=self.auth_encoding)
AttributeError: 'ProxyFromSettingsMiddleware' object has no attribute 'auth_encoding'
```
